### PR TITLE
Make PipeWire socket read-only

### DIFF
--- a/com.thewavewarden.Odin2.json
+++ b/com.thewavewarden.Odin2.json
@@ -8,7 +8,7 @@
         "--socket=x11",
         "--share=ipc",
         "--socket=pulseaudio",
-        "--filesystem=xdg-run/pipewire-0",
+        "--filesystem=xdg-run/pipewire-0:ro",
         "--filesystem=xdg-documents",
         "--persist=.local/share/odin2"
     ],


### PR DESCRIPTION
Flatpaks should not have write access to socket files, like `xdg-run/pipewire-0`. Bidirectional communication is possible regardless of the suffix, so a benevolent app sees no difference. While it shouldn't be possible in theory, it would be best to prevent the possibility of deleting or modifying the socket itself. Flathub maintainers typically request this for new submissions.

https://discourse.flathub.org/t/what-is-the-difference-if-the-pipewire-socket-is-read-only/11951/7